### PR TITLE
add more Base and utility methods

### DIFF
--- a/src/Extents.jl
+++ b/src/Extents.jl
@@ -129,8 +129,10 @@ union(obj1, obj2, obj3, objs...) = union(union(obj1, obj2), obj3, objs...)
 """
     intersect(ext1::Extent, ext2::Extent)
 
-Get the intersect of two extents as another `Extent`, e.g. the area covered by both dimensions.
-If this is empty for any dimension, `nothing` will be returned.
+Get the intersect of two extents as another `Extent`, e.g. 
+the area covered by the shared dimensions for both extents.
+
+If there is no intersection for any shared dimension, `nothing` will be returned.
 """
 function intersect(ext1::Extent, ext2::Extent)
     intersects(ext1, ext2) || return nothing

--- a/src/Extents.jl
+++ b/src/Extents.jl
@@ -16,10 +16,17 @@ in the order the dimensions are used in the object.
 
 `values` will return a tuple of tuples: `(lowerbound, upperbound)` for each dimension.
 """
-struct Extent{T<:NamedTuple}
-    bounds::T
+struct Extent{K,V}
+    bounds::NamedTuple{K,V}
+    function Extent{K,V}(bounds::NamedTuple{K,V}) where {K,V}
+        bounds = map(b -> promote(b...), bounds)
+        new{K,typeof(values(bounds))}(bounds)
+    end
 end
 Extent(; kw...) = Extent(values(kw))
+Extent{K}(vals::V) where {K,V} = Extent{K,V}(NamedTuple{K,V}(vals))
+Extent{K1}(vals::NamedTuple{K2,V}) where {K1,K2,V} = Extent(NamedTuple{K1}(vals))
+Extent(vals::NamedTuple{K,V}) where {K,V} = Extent{K,V}(vals)
 
 bounds(ext::Extent) = getfield(ext, :bounds)
 
@@ -27,23 +34,36 @@ function Base.getproperty(ext::Extent, key::Symbol)
     haskey(bounds(ext), key) || throw(ErrorException("Extent has no field $key"))
     getproperty(bounds(ext), key)
 end
-function Base.getindex(ext::Extent, key::Symbol)
+
+Base.getindex(ext::Extent, keys::NTuple{<:Any,Symbol}) = Extent{keys}(bounds(ext))
+Base.getindex(ext::Extent, keys::AbstractVector{Symbol}) = ext[Tuple(keys)]
+@inline function Base.getindex(ext::Extent, key::Symbol)
     haskey(bounds(ext), key) || throw(ErrorException("Extent has no field $key"))
     getindex(bounds(ext), key)
 end
-function Base.getindex(ext::Extent, i::Int)
+@inline function Base.getindex(ext::Extent, i::Int)
     haskey(bounds(ext), i) || throw(ErrorException("Extent has no field $i"))
     getindex(bounds(ext), i)
 end
-Base.keys(ext::Extent{<:NamedTuple}) = keys(bounds(ext))
+Base.haskey(ext::Extent, x) = haskey(bounds(ext), x)
+Base.keys(ext::Extent) = keys(bounds(ext))
 Base.values(ext::Extent) = values(bounds(ext))
+Base.length(ext::Extent) = length(bounds(ext))
+Base.iterate(ext::Extent, args...) = iterate(bounds(ext), args...)
 
-function Base.:(==)(a::Extent{<:NamedTuple{K1}}, b::Extent{<:NamedTuple{K2}}) where {K1, K2}
+function Base.:(==)(a::Extent{K1}, b::Extent{K2}) where {K1, K2}
     length(K1) == length(K2) || return false
-    all(map(k -> k in K1, K2)) || return false
-    return all(map((k -> a[k] == b[k]), K1))
+    keys_match = map(K2) do k
+        k in K1
+    end
+    all(keys_match) || return false
+    values_match = map(K1) do k
+        va = a[k] 
+        vb = b[k]
+        isnothing(va) && isnothing(vb) || va == vb
+    end
+    return all(values_match)
 end
-Base.:(==)(a::Extent, b::Extent) = false
 
 function Base.show(io::IO, ::MIME"text/plain", extent::Extent)
     print(io, "Extent")
@@ -59,5 +79,83 @@ function extent end
 
 extent(extent) = nothing
 extent(extent::Extent) = extent
+
+"""
+    intersects(ext1::Extent, ext2::Extent)
+
+Check if two `Extent` objects intersect. 
+
+Returns `true` if the extents of all common dimensions share some values
+including just the edge values of thier range. 
+
+Dimensions that are not shared are ignored. The order of dimensions is also ignored.
+
+If there are no common dimensions, `false` is returned.
+"""
+function intersects(ext1::Extent{K1}, ext2::Extent{K2}) where {K1, K2}
+    keys = _shared_keys(ext1, ext2)
+    if length(keys) == 0 
+        return false # Otherwise `all` returns `true` for empty tuples
+    else
+        dimintersections = map(k -> _bounds_intersect(ext1[unwrap(k)], ext2[unwrap(k)]), keys)
+        return all(dimintersections)
+    end
+end
+intersects(obj1, obj2) = intersects(extent(obj1), extent(obj2))
+intersects(obj1::Extent, obj2::Nothing) = false
+intersects(obj1::Nothing, obj2::Extent) = false
+intersects(obj1::Nothing, obj2::Nothing) = false
+
+"""
+    union(ext1::Extent, ext2::Extent)
+
+Get the union of two extents, e.g. the combined extent of both objects
+for all dimensions.
+"""
+function union(ext1::Extent{K1}, ext2::Extent{K2}) where {K1, K2}
+    keys = _shared_keys(ext1, ext2)
+    map(keys) do k
+        k = unwrap(k)
+        k_exts = (ext1[k], ext2[k])
+        min(map(first, k_exts)...), max(map(last, k_exts)...)
+    end |> Extent{map(unwrap, keys)}
+end
+union(obj1, obj2) = union(extent(obj1), extent(obj2))
+union(obj1, obj2, obj3, objs...) = union(union(obj1, obj2), obj3, objs...)
+
+"""
+    intersect(ext1::Extent, ext2::Extent)
+
+Get the intersect of two extents as another `Extent`, e.g. the area covered by both dimensions.
+If this is empty for any dimension, `nothing` will be returned.
+"""
+function intersect(ext1::Extent, ext2::Extent)
+    intersects(ext1, ext2) || return nothing
+    keys = _shared_keys(ext1, ext2)
+    values = map(keys) do k
+        k = unwrap(k)
+        k_exts = (ext1[k], ext2[k])
+        a = max(map(first, k_exts)...)
+        b = min(map(last, k_exts)...)
+        (a, b)
+    end
+    return Extent{keys}(values)
+end
+intersect(obj1, obj2) = intersect(extent(obj1), extent(obj2))
+intersect(obj1, obj2, obj3, objs...) = intersect(intersect(obj1, obj2), obj3, objs...)
+
+function _bounds_intersect(b1::Tuple, b2::Tuple)
+    (b1[1] <= b2[2] && b1[2] >= b2[1])
+end
+
+function _shared_keys(ext1::Extent{K1}, ext2::Extent{K2}) where {K1,K2}
+    reduce(K1; init=()) do acc, k
+        # Use a static Val{k} here instead of a Symbol
+        # This makes union/intersect 15x faster
+        k in K2 ? (acc..., Val{k}()) : acc
+    end
+end
+
+unwrap(::Val{X}) where X = X
 
 end

--- a/src/Extents.jl
+++ b/src/Extents.jl
@@ -86,7 +86,7 @@ extent(extent::Extent) = extent
 Check if two `Extent` objects intersect.
 
 Returns `true` if the extents of all common dimensions share some values
-including just the edge values of thier range.
+including just the edge values of their range.
 
 Dimensions that are not shared are ignored. The order of dimensions is also ignored.
 

--- a/src/Extents.jl
+++ b/src/Extents.jl
@@ -114,11 +114,12 @@ for all dimensions.
 """
 function union(ext1::Extent{K1}, ext2::Extent{K2}) where {K1, K2}
     keys = _shared_keys(ext1, ext2)
-    map(keys) do k
+    values = map(keys) do k
         k = unwrap(k)
         k_exts = (ext1[k], ext2[k])
         min(map(first, k_exts)...), max(map(last, k_exts)...)
-    end |> Extent{map(unwrap, keys)}
+    end 
+    return Extent{map(unwrap, keys)}(values)
 end
 union(obj1, obj2) = union(extent(obj1), extent(obj2))
 union(obj1, obj2, obj3, objs...) = union(union(obj1, obj2), obj3, objs...)
@@ -139,7 +140,7 @@ function intersect(ext1::Extent, ext2::Extent)
         b = min(map(last, k_exts)...)
         (a, b)
     end
-    return Extent{keys}(values)
+    return Extent{map(unwrap, keys)}(values)
 end
 intersect(obj1, obj2) = intersect(extent(obj1), extent(obj2))
 intersect(obj1, obj2, obj3, objs...) = intersect(intersect(obj1, obj2), obj3, objs...)

--- a/src/Extents.jl
+++ b/src/Extents.jl
@@ -117,7 +117,9 @@ function union(ext1::Extent{K1}, ext2::Extent{K2}) where {K1, K2}
     values = map(keys) do k
         k = unwrap(k)
         k_exts = (ext1[k], ext2[k])
-        min(map(first, k_exts)...), max(map(last, k_exts)...)
+        a = min(map(first, k_exts)...)
+        b = max(map(last, k_exts)...)
+        (a, b)
     end 
     return Extent{map(unwrap, keys)}(values)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,11 +40,13 @@ end
     @test Extents.union(a, b) == Extent(X=(0.1, 2.5), Y=(1.0, 4.0))
 end
 
-@testset "intersect" begin
+@testset "intersect/intersects" begin
     a = Extent(X=(0.1, 0.5), Y=(1.0, 2.0))
     b = Extent(X=(2.1, 2.5), Y=(3.0, 4.0), Z=(0.0, 1.0))
     c = Extent(X=(0.4, 2.5), Y=(1.5, 4.0), Z=(0.0, 1.0))
     @code_native Extents.union(a, b)
+    @test Extents.intersects(a, b) == false
     @test Extents.intersect(a, b) == nothing
+    @test Extents.intersects(a, c) == true
     @test Extents.intersect(a, c) == Extent(X=(0.4, 0.5), Y=(1.5, 2.0))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -44,7 +44,6 @@ end
     a = Extent(X=(0.1, 0.5), Y=(1.0, 2.0))
     b = Extent(X=(2.1, 2.5), Y=(3.0, 4.0), Z=(0.0, 1.0))
     c = Extent(X=(0.4, 2.5), Y=(1.5, 4.0), Z=(0.0, 1.0))
-    @code_native Extents.union(a, b)
     @test Extents.intersects(a, b) == false
     @test Extents.intersect(a, b) == nothing
     @test Extents.intersects(a, c) == true

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -45,7 +45,9 @@ end
     b = Extent(X=(2.1, 2.5), Y=(3.0, 4.0), Z=(0.0, 1.0))
     c = Extent(X=(0.4, 2.5), Y=(1.5, 4.0), Z=(0.0, 1.0))
     @test Extents.intersects(a, b) == false
-    @test Extents.intersect(a, b) == nothing
+    @test Extents.intersect(a, b) === nothing
     @test Extents.intersects(a, c) == true
+    @test Extents.intersects(a, c; strict=true) == false
     @test Extents.intersect(a, c) == Extent(X=(0.4, 0.5), Y=(1.5, 2.0))
+    @test Extents.intersect(a, c; strict=true) === nothing
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,28 +1,50 @@
 using Extents
 using Test
 
-@testset "Extents.jl" begin
-    ex1 = Extent(X=(1, 2), Y=(3, 4)) 
-    ex2 = Extent(Y=(3, 4), X=(1, 2))
-    ex3 = Extent(X=(1, 2), Y=(3, 4), Z=(5.0, 6.0)) 
+ex1 = Extent(X=(1, 2), Y=(3, 4)) 
+ex2 = Extent(Y=(3, 4), X=(1, 2))
+ex3 = Extent(X=(1, 2), Y=(3, 4), Z=(5.0, 6.0)) 
 
-    @testset "bounds" begin
-        @test bounds(ex1) === (X=(1, 2), Y=(3, 4))
-        @test bounds(ex2) === (Y=(3, 4), X=(1, 2))
-        @test bounds(ex3) === (X=(1, 2), Y=(3, 4), Z=(5.0, 6.0)) 
-    end
+@testset "getindex" begin
+    @test ex3[1] == ex3[:X] == (1, 2)
+    @test ex3[[:X, :Z]] == ex3[(:X, :Z)] == Extent{(:X,:Z)}(((1, 2), (5.0, 6.0)))
+end
 
-    @testset "extent" begin
-        @test extent(ex1) === ex1
-    end
+@testset "getproperty" begin
+    @test ex3.X == (1, 2)
+end
 
-    @testset "equality" begin
-        @test ex1 == ex2
-        @test ex1 != ex3
-    end
+@testset "bounds" begin
+    @test bounds(ex1) === (X=(1, 2), Y=(3, 4))
+    @test bounds(ex2) === (Y=(3, 4), X=(1, 2))
+    @test bounds(ex3) === (X=(1, 2), Y=(3, 4), Z=(5.0, 6.0)) 
+end
 
-    @testset "properties" begin
-        @test keys(ex1) == (:X, :Y)
-        @test values(ex1) == ((1, 2), (3, 4))
-    end
+@testset "extent" begin
+    @test extent(ex1) === ex1
+end
+
+@testset "equality" begin
+    @test ex1 == ex2
+    @test ex1 != ex3
+end
+
+@testset "properties" begin
+    @test keys(ex1) == (:X, :Y)
+    @test values(ex1) == ((1, 2), (3, 4))
+end
+
+@testset "union" begin
+    a = Extent(X=(0.1, 0.5), Y=(1.0, 2.0))
+    b = Extent(X=(2.1, 2.5), Y=(3.0, 4.0), Z=(0.0, 1.0))
+    @test Extents.union(a, b) == Extent(X=(0.1, 2.5), Y=(1.0, 4.0))
+end
+
+@testset "intersect" begin
+    a = Extent(X=(0.1, 0.5), Y=(1.0, 2.0))
+    b = Extent(X=(2.1, 2.5), Y=(3.0, 4.0), Z=(0.0, 1.0))
+    c = Extent(X=(0.4, 2.5), Y=(1.5, 4.0), Z=(0.0, 1.0))
+    @code_native Extents.union(a, b)
+    @test Extents.intersect(a, b) == nothing
+    @test Extents.intersect(a, c) == Extent(X=(0.4, 0.5), Y=(1.5, 2.0))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,13 +1,13 @@
 using Extents
 using Test
 
-ex1 = Extent(X=(1, 2), Y=(3, 4)) 
+ex1 = Extent(X=(1, 2), Y=(3, 4))
 ex2 = Extent(Y=(3, 4), X=(1, 2))
-ex3 = Extent(X=(1, 2), Y=(3, 4), Z=(5.0, 6.0)) 
+ex3 = Extent(X=(1, 2), Y=(3, 4), Z=(5.0, 6.0))
 
 @testset "getindex" begin
     @test ex3[1] == ex3[:X] == (1, 2)
-    @test ex3[[:X, :Z]] == ex3[(:X, :Z)] == Extent{(:X,:Z)}(((1, 2), (5.0, 6.0)))
+    @test ex3[[:X, :Z]] == ex3[(:X, :Z)] == Extent{(:X, :Z)}(((1, 2), (5.0, 6.0)))
 end
 
 @testset "getproperty" begin
@@ -17,7 +17,7 @@ end
 @testset "bounds" begin
     @test bounds(ex1) === (X=(1, 2), Y=(3, 4))
     @test bounds(ex2) === (Y=(3, 4), X=(1, 2))
-    @test bounds(ex3) === (X=(1, 2), Y=(3, 4), Z=(5.0, 6.0)) 
+    @test bounds(ex3) === (X=(1, 2), Y=(3, 4), Z=(5.0, 6.0))
 end
 
 @testset "extent" begin
@@ -47,10 +47,12 @@ end
     a = Extent(X=(0.1, 0.5), Y=(1.0, 2.0))
     b = Extent(X=(2.1, 2.5), Y=(3.0, 4.0), Z=(0.0, 1.0))
     c = Extent(X=(0.4, 2.5), Y=(1.5, 4.0), Z=(0.0, 1.0))
+    d = Extent(A=(0.0, 1.0))
     @test Extents.intersects(a, b) == false
     @test Extents.intersect(a, b) === nothing
     @test Extents.intersects(a, c) == true
     @test Extents.intersects(a, c; strict=true) == false
     @test Extents.intersect(a, c) == Extent(X=(0.4, 0.5), Y=(1.5, 2.0))
+    @test Extents.intersect(a, d) === nothing
     @test Extents.intersect(a, c; strict=true) === nothing
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -37,7 +37,10 @@ end
 @testset "union" begin
     a = Extent(X=(0.1, 0.5), Y=(1.0, 2.0))
     b = Extent(X=(2.1, 2.5), Y=(3.0, 4.0), Z=(0.0, 1.0))
+    c = Extent(Z=(0.2, 2.0))
     @test Extents.union(a, b) == Extent(X=(0.1, 2.5), Y=(1.0, 4.0))
+    @test Extents.union(a, b; strict=true) === nothing
+    @test Extents.union(a, c) === nothing
 end
 
 @testset "intersect/intersects" begin


### PR DESCRIPTION
This PR adds utility methods:
- `intersects`:  returns a `Bool` (can we think of a better name more different to `intersect`?
- `intersect` returns the intersection `Extent` or `nothing` if there is no intersection.
- `union` gets the union extent. I'm not sure if it should include all dimensions or only the shared dimensions? what makes sense here.

For this to work well, and for other uses in Rasters.jl/DimensionalData.jl, I also added Base methods and did some work on the type to make `Extent` more similar to `NamedTuple`.

Use of `Val` in keys is so all the named tuple indexing compiles away - which gives 15ns `union` and `intersect` rather than `300ns`.

@evetion if you could have a look over this that would be great