### PR TITLE
stricter inner constructor

### DIFF
--- a/src/Extents.jl
+++ b/src/Extents.jl
@@ -18,8 +18,9 @@ in the order the dimensions are used in the object.
 """
 struct Extent{K,V}
     bounds::NamedTuple{K,V}
-    function Extent{K,V}(bounds::NamedTuple{K,V}) where {K,V}
-        bounds = map(b -> promote(b...), bounds)
+    function Extent{K,V}(bounds::NamedTuple{K,V}) where {K, V <: NTuple{N,Tuple{Real, Real}}} where {N}
+        N == 0 && error("Extent needs at least one dimension")
+        bounds = map(b -> minmax(promote(b...)...), bounds)
         new{K,typeof(values(bounds))}(bounds)
     end
 end

--- a/src/Extents.jl
+++ b/src/Extents.jl
@@ -18,7 +18,7 @@ in the order the dimensions are used in the object.
 """
 struct Extent{K,V}
     bounds::NamedTuple{K,V}
-    function Extent{K,V}(bounds::NamedTuple{K,V}) where {K, V <: NTuple{N,Tuple{Real, Real}}} where {N}
+    function Extent{K,V}(bounds::NamedTuple{K,V}) where {K, V <: NTuple{N,Tuple{Any, Any}}} where {N}
         N == 0 && error("Extent needs at least one dimension")
         bounds = map(b -> minmax(promote(b...)...), bounds)
         new{K,typeof(values(bounds))}(bounds)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,26 @@ ex1 = Extent(X=(1, 2), Y=(3, 4))
 ex2 = Extent(Y=(3, 4), X=(1, 2))
 ex3 = Extent(X=(1, 2), Y=(3, 4), Z=(5.0, 6.0))
 
+@testset "constructors" begin
+    # extent per dimension is promoted to a common type
+    x = Extent(X=(1, 2.0))
+    @test x isa Extent{(:X,), Tuple{NTuple{2, Float64}}}
+    # but different types per dimension are kept
+    x = Extent(X=(1, 2), Y=(3, 4.0))
+    @test x isa Extent{(:X, :Y), Tuple{NTuple{2, Int64}, NTuple{2, Float64}}}
+    # each dimension needs a size two Tuple
+    @test_throws ErrorException Extent()
+    @test_throws MethodError Extent(X=(2,))
+    @test_throws MethodError Extent(X=(2,3,4))
+    # with Real components
+    @test_throws MethodError Extent(X=(Complex(1), Complex(2)))
+    @test_throws MethodError Extent(X=([1], [2]))
+    # extents are sorted
+    x = Extent(X=(2.0, 1), Y=(4,3))
+    @test x.X === (1.0, 2.0)
+    @test x.Y === (3, 4)
+end
+
 @testset "getindex" begin
     @test ex3[1] == ex3[:X] == (1, 2)
     @test ex3[[:X, :Z]] == ex3[(:X, :Z)] == Extent{(:X, :Z)}(((1, 2), (5.0, 6.0)))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,13 +16,14 @@ ex3 = Extent(X=(1, 2), Y=(3, 4), Z=(5.0, 6.0))
     @test_throws ErrorException Extent()
     @test_throws MethodError Extent(X=(2,))
     @test_throws MethodError Extent(X=(2,3,4))
-    # with Real components
+    # needs isless; must be sortable
     @test_throws MethodError Extent(X=(Complex(1), Complex(2)))
-    @test_throws MethodError Extent(X=([1], [2]))
     # extents are sorted
     x = Extent(X=(2.0, 1), Y=(4,3))
     @test x.X === (1.0, 2.0)
     @test x.Y === (3, 4)
+    @test Extent(channel=('b', 'a')).channel  === ('a', 'b')
+    @test Extent(channel=("bee", "aa")).channel  === ("aa", "bee")
 end
 
 @testset "getindex" begin


### PR DESCRIPTION
Fixes #4.

This now enforces 3 things:

1. Numbers are Real
2. Per dimension the extent has two Reals
3. The extent per dimension is sorted on construction

Do we want to enforce all these 3? I'm not sure about Real, perhaps anything that has order is fine. E.g. do we want this to work with say a 2D netCDF matrix that has Real Z and String Station dimensions? Or for instance with Unitful.jl, which are Number, not Real?

And does it make sense to sort on construction, or would it be preferred to error if it is not sorted?