### PR TITLE
fix stack overflow in union and intersection

### DIFF
--- a/src/Extents.jl
+++ b/src/Extents.jl
@@ -164,6 +164,9 @@ function union(ext1::Extent, ext2::Extent; strict=false)
         return Extent{map(_unwrap, keys)}(values)
     end
 end
+union(obj1, ::Nothing) = obj1
+union(::Nothing, obj2) = obj2
+union(::Nothing, ::Nothing) = nothing
 union(obj1, obj2) = union(extent(obj1), extent(obj2))
 union(obj1, obj2, obj3, objs...) = union(union(obj1, obj2), obj3, objs...)
 
@@ -190,6 +193,9 @@ function intersection(ext1::Extent, ext2::Extent; strict=false)
     return Extent{map(_unwrap, keys)}(values)
 end
 
+intersection(obj1, obj2::Nothing) = nothing
+intersection(obj1::Nothing, obj2) = nothing
+intersection(obj1::Nothing, obj2::Nothing) = nothing
 intersection(obj1, obj2) = intersection(extent(obj1), extent(obj2))
 intersection(obj1, obj2, obj3, objs...) = intersection(intersection(obj1, obj2), obj3, objs...)
 

--- a/src/Extents.jl
+++ b/src/Extents.jl
@@ -164,8 +164,8 @@ function union(ext1::Extent, ext2::Extent; strict=false)
         return Extent{map(_unwrap, keys)}(values)
     end
 end
-union(obj1, ::Nothing) = obj1
-union(::Nothing, obj2) = obj2
+union(obj1::Extent, ::Nothing) = obj1
+union(::Nothing, obj2::Extent) = obj2
 union(::Nothing, ::Nothing) = nothing
 union(obj1, obj2) = union(extent(obj1), extent(obj2))
 union(obj1, obj2, obj3, objs...) = union(union(obj1, obj2), obj3, objs...)
@@ -192,9 +192,8 @@ function intersection(ext1::Extent, ext2::Extent; strict=false)
     end
     return Extent{map(_unwrap, keys)}(values)
 end
-
-intersection(obj1, obj2::Nothing) = nothing
-intersection(obj1::Nothing, obj2) = nothing
+intersection(obj1::Extent, obj2::Nothing) = nothing
+intersection(obj1::Nothing, obj2::Extent) = nothing
 intersection(obj1::Nothing, obj2::Nothing) = nothing
 intersection(obj1, obj2) = intersection(extent(obj1), extent(obj2))
 intersection(obj1, obj2, obj3, objs...) = intersection(intersection(obj1, obj2), obj3, objs...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -51,6 +51,9 @@ end
     @test Extents.union(a, b) == Extent(X=(0.1, 2.5), Y=(1.0, 4.0))
     @test Extents.union(a, b; strict=true) === nothing
     @test Extents.union(a, c) === nothing
+    @test Extents.union(a, nothing) === a
+    @test Extents.union(nothing, a) === a
+    @test Extents.union(nothing, nothing) === nothing
 end
 
 @testset "intersection/intersects" begin
@@ -65,4 +68,7 @@ end
     @test Extents.intersection(a, c) == Extent(X=(0.4, 0.5), Y=(1.5, 2.0))
     @test Extents.intersection(a, d) === nothing
     @test Extents.intersection(a, c; strict=true) === nothing
+    @test Extents.intersection(a, nothing) === nothing
+    @test Extents.intersection(nothing, nothing) === nothing
+    @test Extents.intersection(nothing, b) === nothing
 end


### PR DESCRIPTION
`union(hasextent, nothingextent)` was causing overflow. `instesection` the same.

Now `union` will return whichever is an extent, and `intersection` will just return nothing. Not 100% sure `union` should return anything when one object has no `Extent`.