### PR TITLE
add cycled dims and crs capacity

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,7 @@ const E = Extent
 ex1 = Extent(X=(1, 2), Y=(3, 4))
 ex2 = Extent(Y=(3, 4), X=(1, 2))
 ex3 = Extent(X=(1, 2), Y=(3, 4), Z=(5.0, 6.0))
+ex1 = Extent(X=Extents.Bounds(1, 2), Y=(3, 4))
 
 struct HasExtent end
 Extents.extent(::HasExtent) = Extent(X=(0, 1), Y=(0, 1))
@@ -73,7 +74,7 @@ end
 
 @testset "covers" begin
     # An extent contains itself
-    @test Extents.covers(E(X=(2, 3), Y=(3, 4)), E(X=(2, 3), Y=(3, 4))) == true
+    @test Extents.covers(E(X=Extents.Bounds(2, 3), Y=(3, 4)), E(X=(2, 3), Y=(3, 4))) == true
     # A larger extent covers a smaller one inside it
     @test Extents.covers(E(X=(0, 4), Y=(1, 5)), E(X=(2, 3), Y=(3, 4))) == true
     # Intersecting but not covers in one dimension
@@ -103,7 +104,7 @@ end
 
 @testset "coveredby" begin
     # An extent contains itself
-    @test Extents.coveredby(E(X=(2, 3), Y=(3, 4)), E(X=(2, 3), Y=(3, 4))) == true
+    @test Extents.coveredby(E(X=Extents.Bounds(2, 3), Y=(3, 4)), E(X=(2, 3), Y=(3, 4))) == true
     # A larger extent coveredby a smaller one inside it
     @test Extents.contains(E(X=(0, 4), Y=(1, 5)), E(X=(2, 3), Y=(3, 4))) == true
     @test Extents.coveredby(E(X=(2, 3), Y=(3, 4)), E(X=(0, 4), Y=(1, 5))) == true
@@ -134,7 +135,7 @@ end
 
 @testset "contains" begin
     # An extent contains itself
-    @test Extents.contains(E(X=(2, 3), Y=(3, 4)), E(X=(2, 3), Y=(3, 4))) == true
+    @test Extents.contains(E(X=(2, 3), Y=(3, 4)), E(X=(2, 3), Y=Extents.Bounds(3, 4))) == true
     # A larger extent contains a smaller one inside it
     @test Extents.contains(E(X=(0, 4), Y=(1, 5)), E(X=(2, 3), Y=(3, 4))) == true
     # Intersecting but not contains in one dimension
@@ -164,7 +165,7 @@ end
 
 @testset "within" begin
     # An extent contains itself
-    @test Extents.within(E(X=(2, 3), Y=(3, 4)), E(X=(2, 3), Y=(3, 4))) == true
+    @test Extents.within(E(X=(2, 3), Y=(3, 4)), E(X=Extents.Bounds(2, 3), Y=(3, 4))) == true
     # A larger extent within a smaller one inside it
     @test Extents.contains(E(X=(0, 4), Y=(1, 5)), E(X=(2, 3), Y=(3, 4))) == true
     @test Extents.within(E(X=(2, 3), Y=(3, 4)), E(X=(0, 4), Y=(1, 5))) == true


### PR DESCRIPTION
@evetion we discussed this some time and I just remembered it. So here it it.

`GeoExtent` capability without a special `GeoExtent` object. We just add `Bounds` and `Cycled` objects that give use bounds with an attached crs or the same that also knows how it cycles, for anti-meridian things. Its duplicating the crs field like Rasters, but that has some nice properties for multidimensional extents, and but we can define `setcrs` for it in GeoInterface to wrap X and Y in Bounds with the crs. 

The trick will be actually writing out the predicates for the `cycled` parts. Like we would interpret reverse order bounds to be crossing the meridean and work in relation to the cycle.

Then it will be knowing where the cycle is at all from the crs. But some other packages will need to deal with that.