### PR TITLE
add pad and grow functions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,8 +18,8 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.5'
-          - '1.7'
+          - 'lts'
+          - '1'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - 'lts'
+          - '1.10'
           - '1'
           - 'nightly'
         os:
@@ -32,7 +32,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v1
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1

--- a/Project.toml
+++ b/Project.toml
@@ -6,7 +6,7 @@ version = "0.1.4"
 [deps]
 
 [compat]
-julia = "1.5"
+julia = "1.10"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/Extents.jl
+++ b/src/Extents.jl
@@ -502,11 +502,13 @@ of the keys as `ext`.  This can hold `Real` or `Tuple{Real,Real}` values for
 each named dimension.
 
 ## Examples
-```jldoctest
-julia> ext = Extent(X = (1.0, 2.0), Y = (3.0, 4.0))
-Extent(X = (1.0, 2.0), Y = (3.0, 4.0))
 
-julia> grow(ext, 0.5)
+```jldoctest
+julia> ext = Extent(X = (1.0, 1.8), Y = (3.0, 5.0))
+Extent(X = (1.0, 1.8), Y = (3.0, 5.0))
+
+julia> Extents.grow(ext, 0.5) 
+Extent(X = (0.6, 2.2), Y = (2.0, 6.0))
 
 ````
 """
@@ -548,6 +550,7 @@ of the keys as `ext`. This can hold `Real` or `Tuple{Real,Real}` values for
 each named dimension.
 
 ## Examples
+
 ```jldoctest
 julia> ext = Extent(X = (1.0, 2.0), Y = (3.0, 4.0))
 Extent(X = (1.0, 2.0), Y = (3.0, 4.0))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -370,3 +370,17 @@ end
     @test Extents.buffer(b, (Lat=2, Lon=1)) == Extent(Lat=(-1.9, 2.5), Lon=(0.0, 3.0), Elev=(-3, 4))
     @test Extents.buffer(c, (X=2, Y=2, Ti=Year(1))) == Extent(X=(-1.9, 2.5), Y=(-1.0, 4.0), Ti=(DateTime("1999-01-01T00:00:00"), DateTime("2021-01-01T00:00:00")))
 end
+
+@testset "pad" begin
+    a = Extent(X=(0.1, 0.5), Y=(1.0, 2.0))
+    @test Extents.pad(a, (X=0.1, Y=0.2)) == Extent(X=(0.0, 0.6), Y=(0.8, 2.2))
+    @test Extents.pad(a, 1) == Extent(X=(-0.9, 1.5), Y=(0.0, 3.0))
+    @test Extents.pad(a; Y=2) == Extent(X=(0.1, 0.5), Y=(-1.0, 4.0))
+    @test Extents.pad(a, (Y=2, X=0.1)) == Extent(X=(0.0, 0.6), Y=(-1.0, 4.0))
+end
+
+@testset "grow" begin
+    a = Extent(X=(1.0, 2.0), Y=(4.0, 8.0))
+    @test Extents.grow(a, 0.5) == Extent(X=(0.5, 2.5), Y=(2.0, 10.0))
+    @test Extents.grow(a, (X=0.1, Y=0.5)) == Extent(X=(0.9, 2.1), Y=(2.0, 10.0))
+end


### PR DESCRIPTION
I realized writing `grow` that people would be confused if it scales or pads the extent. So we have `grow` and `pad` to make it clear which does what.

`grow` grows or shrinks by some fraction of the current size, `pad` adds or removes a specific amount of padding.

Closes #32

@asinghvi17 want to review?