### PR TITLE
Add single argument predicates

### DIFF
--- a/src/Extents.jl
+++ b/src/Extents.jl
@@ -273,10 +273,11 @@ https://en.wikipedia.org/wiki/DE-9IM
 """
 
 """
-    contains(a::Extent, b::Extent; strict=false)
+    contains(a, b; strict=false)
+    contains(b; strict=false)(a)
 
-`a` contains `b` if no points of `b` lie in the exterior of `a`, and 
-at least one point of the interior of `b` lies in the interior of `a`.
+Extent `a` contains extent `b` if no points of `b` lie in the exterior of `a`, 
+and at least one point of the interior of `b` lies in the interior of `a`.
 If `b` has no interior points it is not contained in `a`.
 
 Identical to [`within`](@ref) with argument order reversed.
@@ -295,10 +296,11 @@ contains(a::Extent, b::Extent; strict=false) = _do_bounds(all, _contain, a, b, s
 _contain(a::Tuple, b::Tuple) = _cover(a, b) && _hasinterior(b)
 
 """
-    within(a::Extent, b::Extent; strict=false)
+    within(a, b; strict=false)
+    within(b; strict=false)(a)
 
-`a` is within `b` if no points of `a` lie in the exterior of `b`, and 
-at least one point of the interior of `a` lies in the interior of `b`.
+Extent `a` is within extent `b` if no points of `a` lie in the exterior of `b`, 
+and at least one point of the interior of `a` lies in the interior of `b`.
 If `a` has no interior points it is not contained in `b`.
 
 Identical to [`contains`](@ref) with argument order reversed.
@@ -314,7 +316,8 @@ $DE_9IM_DOC
 within(a, b; kw...) = contains(b, a; kw...) # swapped order of `contains`
 
 """
-    intersects(a::Extent, b::Extent; strict=false)
+    intersects(a, b; strict=false)
+    intersects(b; strict=false)(a)
 
 `a` intersects `b` if `a` and `b` have at least one point in common
 (the inverse of [`disjoint`](@ref)).
@@ -336,9 +339,10 @@ _intersect((min_a, max_a)::Tuple, (min_b, max_b)::Tuple) =
     (min_a <= min_b && max_a >= min_b) || (min_b <= min_a && max_b >= min_a)
 
 """
-    disjoint(a::Extent, b::Extent; strict=false)
+    disjoint(a, b; strict=false)
+    disjoint(b; strict=false)(a)
 
-`a` and `b` are disjoint if they have no point in common
+Extents `a` and `b` are disjoint if they have no point in common
 (the inverse of [`intersects`](@ref)).
 
 Returns `false` if the extents of all common dimensions share some values,
@@ -355,9 +359,10 @@ $DE_9IM_DOC
 disjoint(a, b; kw...) = !intersects(a, b; kw...)
 
 """
-    touches(a::Extent, b::Extent; strict=false)
+    touches(a, b; strict=false)
+    touches(b; strict=false)(a)
 
-`a` and `b` have at least one point in common, but their interiors do not intersect. 
+Extents `a` and `b` have at least one point in common, but their interiors do not intersect. 
 
 Returns `true` if the extents of any common dimensions share boundaries.
 
@@ -382,9 +387,12 @@ _touch((min_a, max_a)::Tuple, (min_b, max_b)::Tuple) = (min_a == max_b || max_a 
 
 
 """
-    covers(a::Extent, b::Extent; strict=false)
+    covers(a, b; strict=false)
+    covers(b; strict=false)(a)
 
-At least one point of `b` lies in `a`, and no point of `b` lies in the exterior of `a`,
+At least one point of extent `b` lies in extent `a`, 
+and no point of `b` lies in the exterior of `a`.
+
 Every point of `b` is a point in the interior or boundary of `a`. 
 
 Identical to [`coveredby`](@ref) with argument order reversed.
@@ -402,9 +410,12 @@ covers(a::Extent, b::Extent; strict=false) = _do_bounds(all, _cover, a, b, stric
 _cover((min_a, max_a)::Tuple, (min_b, max_b)::Tuple) = (min_a <= min_b && max_a >= max_b)
 
 """
-    coveredby(a::Extent, b::Extent; strict=false)
+    coveredby(a, b; strict=false)
+    coveredby(b; strict=false)(a)
 
-At least one point of `a` lies in `b`, and no point of `a` lies in the exterior of `b`,
+At least one point of extent `a` lies in extent `b`, 
+and no point of `a` lies in the exterior of `b`.
+
 Every point of `a` is a point in the interior or boundary of `b`. 
 
 Identical to [`covers`](@ref) with argument order reversed.
@@ -421,9 +432,10 @@ coveredby(a, b; kw...) = covers(b, a; kw...) # swapped order of `covers`
 
 
 """
-    overlaps(a::Extent, b::Extent; strict=false)
+    overlaps(a, b; strict=false)
+    overlaps(b; strict=false)(a)
 
-`a` overlaps `b`: they have some but not all points in common, 
+Extent `a` overlaps extent `b`: they have some but not all points in common, 
 they have the same dimension, and the intersection of the interiors
 of the two geometries has the same dimension as the geometries themselves.
 
@@ -448,9 +460,10 @@ end
 
 """
     equals(a, b; strict=false)
+    equals(b; strict=false)(a)
 
-`a` and `b` are topologically equal: their interiors intersect and no part
-of the interior or boundary of one intersects the exterior of the other.
+Extents `a` and `b` are topologically equal: their interiors intersect and no 
+part of the interior or boundary of one intersects the exterior of the other.
 
 $STRICT_DOC
 

--- a/src/Extents.jl
+++ b/src/Extents.jl
@@ -542,7 +542,6 @@ _unwrap(::Val{X}) where {X} = X
 function _do_bounds(boolreduce::Function, compare::Function, a::Extent, b::Extent, strict::Bool)
     _maybe_check_keys_match(a, b, strict) || return false
     keys = _shared_keys(a, b)
-    @show keys
     if length(keys) == 0
         # There are no shared dimensions. Maybe this should return `nothing`?
         # But we need to handle it otherwise `all` returns `true` for empty tuples

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -381,3 +381,23 @@ end
     @test Extents.grow(a, 0.5) == Extent(X=(0.5, 2.5), Y=(2.0, 10.0))
     @test Extents.grow(a, (X=0.1, Y=0.5)) == Extent(X=(0.9, 2.1), Y=(2.0, 10.0))
 end
+
+@testset "Single argument predicates" begin
+    a = Extent(X=(0.1, 0.5), Y=(1.0, 2.0))
+    b = Extent(X=(0.2, 0.4), Y=(2.0, 5.0), Z=(1, 2))
+    @test Extents.intersects(b)(a) == Extents.intersects(a, b) == true
+    @test Extents.disjoint(b)(a) == Extents.disjoint(a, b) == false
+    @test Extents.touches(b)(a) == Extents.touches(a, b) == true
+    @test Extents.equals(b)(a) == Extents.equals(a, b) == false
+    @test Extents.covers(b)(a) == Extents.covers(a, b) == false
+    @test Extents.coveredby(b)(a) == Extents.coveredby(a, b) == false
+    @test Extents.contains(b)(a) == Extents.contains(a, b) == false
+    @test Extents.within(b)(a) == Extents.within(a, b) == false
+    @test Extents.touches(b)(a) == Extents.touches(a, b) == true
+
+    @testset "strict keyword still works" begin
+        @test Extents.intersects(b; strict=true)(a) == 
+            Extents.intersects(b)(a; strict=true) ==
+            Extents.intersects(a, b; strict=true) == false
+    end
+end


### PR DESCRIPTION
These use Fix2 form, which seems more intuitive with the language, and consistent with GeometryOps.jl

Example:
```julia
covers(b)(a) == covers(a, b)
```